### PR TITLE
친구프로필 페이지 기능 구현

### DIFF
--- a/Picon/app/src/main/AndroidManifest.xml
+++ b/Picon/app/src/main/AndroidManifest.xml
@@ -45,6 +45,7 @@
         <activity android:name=".presentation.postdetail.PostDetailActivity" />
         <activity android:name=".presentation.postdetail.PostDetailImageActivity" />
         <activity android:name=".presentation.pingallery.PinGalleryActivity" />
+        <activity android:name=".presentation.profile.FriendProfileActivity" />
     </application>
 
 </manifest>

--- a/Picon/app/src/main/java/com/yapp/picon/data/api/YappApi.kt
+++ b/Picon/app/src/main/java/com/yapp/picon/data/api/YappApi.kt
@@ -39,6 +39,13 @@ interface YappApi {
     ): PostsResponse
 
     @Headers("Content-Type: application/json;charset=UTF-8")
+    @GET("display/post/member/{id}")
+    suspend fun requestFriendPosts(
+        @Header("AccessToken") accessToken: String,
+        @Path("id") id: Int
+    ): PostsResponse
+
+    @Headers("Content-Type: application/json;charset=UTF-8")
     @DELETE("display/post/{id}")
     suspend fun removePost(
         @Header("AccessToken") accessToken: String,

--- a/Picon/app/src/main/java/com/yapp/picon/data/model/FollowInfo.kt
+++ b/Picon/app/src/main/java/com/yapp/picon/data/model/FollowInfo.kt
@@ -1,0 +1,6 @@
+package com.yapp.picon.data.model
+
+data class FollowInfo (
+    val followers: Int,
+    val followings: Int
+)

--- a/Picon/app/src/main/java/com/yapp/picon/data/model/Member.kt
+++ b/Picon/app/src/main/java/com/yapp/picon/data/model/Member.kt
@@ -6,5 +6,6 @@ data class Member (
     val nickName: String,
     val role: String,
     val createdDate: String,
-    val profileImageUrl: String?
+    val profileImageUrl: String?,
+    val isFollowing: Boolean?
 )

--- a/Picon/app/src/main/java/com/yapp/picon/data/model/UserResponse.kt
+++ b/Picon/app/src/main/java/com/yapp/picon/data/model/UserResponse.kt
@@ -1,9 +1,13 @@
 package com.yapp.picon.data.model
 
+import com.google.gson.annotations.SerializedName
+
 data class UserResponse (
     val status: Int,
     val errors: String,
     val errorCode: String,
     val errorMessage: String,
-    val member: Member
+    @SerializedName("memberDto")
+    val member: Member,
+    val followInfo: FollowInfo
 )

--- a/Picon/app/src/main/java/com/yapp/picon/presentation/di/ViewModelModule.kt
+++ b/Picon/app/src/main/java/com/yapp/picon/presentation/di/ViewModelModule.kt
@@ -7,6 +7,7 @@ import com.yapp.picon.presentation.nav.manageFriend.ManageFriendViewModel
 import com.yapp.picon.presentation.pingallery.PinGalleryViewModel
 import com.yapp.picon.presentation.post.PostViewModel
 import com.yapp.picon.presentation.postdetail.PostDetailViewModel
+import com.yapp.picon.presentation.profile.FriendProfileViewModel
 import com.yapp.picon.presentation.profile.MyProfileViewModel
 import com.yapp.picon.presentation.search.SearchViewModel
 import com.yapp.picon.presentation.simplejoin.SimpleJoinViewModel
@@ -26,4 +27,5 @@ val viewModelModule = module {
     viewModel { MyProfileViewModel() }
     viewModel { PostDetailViewModel(get()) }
     viewModel { ManageFriendViewModel() }
+    viewModel { FriendProfileViewModel() }
 }

--- a/Picon/app/src/main/java/com/yapp/picon/presentation/di/ViewModelModule.kt
+++ b/Picon/app/src/main/java/com/yapp/picon/presentation/di/ViewModelModule.kt
@@ -27,5 +27,5 @@ val viewModelModule = module {
     viewModel { MyProfileViewModel() }
     viewModel { PostDetailViewModel(get()) }
     viewModel { ManageFriendViewModel() }
-    viewModel { FriendProfileViewModel() }
+    viewModel { FriendProfileViewModel(get()) }
 }

--- a/Picon/app/src/main/java/com/yapp/picon/presentation/nav/adapter/CustomEmotionAdapter.kt
+++ b/Picon/app/src/main/java/com/yapp/picon/presentation/nav/adapter/CustomEmotionAdapter.kt
@@ -41,11 +41,10 @@ class CustomEmotionAdapter(
             getResource(items[position].color)
         )
 
-        baseViewHolder.itemView.setOnLongClickListener {
+        baseViewHolder.itemView.setOnClickListener {
             setDialog(it.id)
             dialog.show()
             setDialogSize()
-            true
         }
     }
 

--- a/Picon/app/src/main/java/com/yapp/picon/presentation/nav/manageFriend/ManageFriendActivity.kt
+++ b/Picon/app/src/main/java/com/yapp/picon/presentation/nav/manageFriend/ManageFriendActivity.kt
@@ -81,6 +81,13 @@ class ManageFriendActivity : BaseActivity<ManageFriendActivityBinding, ManageFri
         mainFragment = ManageFriendMainFragment(this)
     }
 
+    override fun onStart() {
+        super.onStart()
+
+        changeToMainFragment()
+        vm.searchText.value = ""
+    }
+
     private fun onHideKeypad() {
         val imm = getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager
         val view: View = currentFocus ?: View(this)

--- a/Picon/app/src/main/java/com/yapp/picon/presentation/nav/manageFriend/ManageFriendFollowAdapter.kt
+++ b/Picon/app/src/main/java/com/yapp/picon/presentation/nav/manageFriend/ManageFriendFollowAdapter.kt
@@ -13,7 +13,8 @@ class ManageFriendFollowAdapter(
     @LayoutRes private val layoutRes: Int,
     bindingVariabledId: Int,
     private val requestFollow: (Int) -> Unit,
-    private val requestUnFollow: (Int) -> Unit
+    private val requestUnFollow: (Int) -> Unit,
+    private val startFriendProfile: (String) -> Unit
 ): BaseRecyclerView.BaseAdapter<FollowItem, ManageFriendTabListItemBinding>(
     layoutRes, bindingVariabledId
 ) {
@@ -23,6 +24,12 @@ class ManageFriendFollowAdapter(
     ) {
         super.onBindViewHolder(baseViewHolder, position)
 
+        baseViewHolder.itemView.friend_list_item_image.setOnClickListener {
+            startFriendProfile(items[position].email)
+        }
+        baseViewHolder.itemView.friend_list_item_email_tv.setOnClickListener {
+            startFriendProfile(items[position].email)
+        }
         setImageView(baseViewHolder, items[position])
         setFollowButton(baseViewHolder, items[position], position)
     }

--- a/Picon/app/src/main/java/com/yapp/picon/presentation/nav/manageFriend/ManageFriendMainFragment.kt
+++ b/Picon/app/src/main/java/com/yapp/picon/presentation/nav/manageFriend/ManageFriendMainFragment.kt
@@ -43,15 +43,17 @@ class ManageFriendMainFragment(
     }
 
     private fun setPagerAdapter() {
-        pagerAdapter = ManageFriendPagerAdapter(application)
-        binding.manageFriendViewPager.adapter = pagerAdapter
+        if (binding.manageFriendViewPager.adapter == null) {
+            pagerAdapter = ManageFriendPagerAdapter(application)
+            binding.manageFriendViewPager.adapter = pagerAdapter
 
-        TabLayoutMediator(
-            binding.manageFriendTabLayout,
-            binding.manageFriendViewPager
-        ) { tab, position ->
-            if (position == 0) tab.text = getString(R.string.my_profile_following)
-            else tab.text = getString(R.string.my_profile_follower)
-        }.attach()
+            TabLayoutMediator(
+                binding.manageFriendTabLayout,
+                binding.manageFriendViewPager
+            ) { tab, position ->
+                if (position == 0) tab.text = getString(R.string.my_profile_following)
+                else tab.text = getString(R.string.my_profile_follower)
+            }.attach()
+        }
     }
 }

--- a/Picon/app/src/main/java/com/yapp/picon/presentation/nav/manageFriend/ManageFriendSearchFragment.kt
+++ b/Picon/app/src/main/java/com/yapp/picon/presentation/nav/manageFriend/ManageFriendSearchFragment.kt
@@ -1,5 +1,6 @@
 package com.yapp.picon.presentation.nav.manageFriend
 
+import android.content.Intent
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
@@ -8,6 +9,7 @@ import com.yapp.picon.BR
 import com.yapp.picon.R
 import com.yapp.picon.databinding.ManageFriendSearchFragmentBinding
 import com.yapp.picon.presentation.base.BaseFragment
+import com.yapp.picon.presentation.profile.FriendProfileActivity
 
 class ManageFriendSearchFragment: BaseFragment<ManageFriendSearchFragmentBinding, ManageFriendViewModel>(
     R.layout.manage_friend_search_fragment
@@ -31,7 +33,8 @@ class ManageFriendSearchFragment: BaseFragment<ManageFriendSearchFragmentBinding
             R.layout.manage_friend_tab_list_item,
             BR.followItem,
             {id -> requestFollow(id)},
-            {id -> requestUnFollow(id)}
+            {id -> requestUnFollow(id)},
+            {identity -> startFriendProfile(identity)}
         )
         binding.manageFriendSearchRv.apply {
             adapter = searchAdapter
@@ -55,5 +58,12 @@ class ManageFriendSearchFragment: BaseFragment<ManageFriendSearchFragmentBinding
         if (vm.token.isNotEmpty()) {
             vm.requestUnFollow(vm.token, id)
         } else vm.showToast("언팔로우 실패")
+    }
+
+    private fun startFriendProfile(identity: String) {
+        startActivity(
+            Intent(context, FriendProfileActivity::class.java)
+                .putExtra("identity", identity)
+        )
     }
 }

--- a/Picon/app/src/main/java/com/yapp/picon/presentation/nav/manageFriend/ManageFriendTabFragment.kt
+++ b/Picon/app/src/main/java/com/yapp/picon/presentation/nav/manageFriend/ManageFriendTabFragment.kt
@@ -1,5 +1,6 @@
 package com.yapp.picon.presentation.nav.manageFriend
 
+import android.content.Intent
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
@@ -8,6 +9,7 @@ import com.yapp.picon.BR
 import com.yapp.picon.R
 import com.yapp.picon.databinding.ManageFriendTabFragmentBinding
 import com.yapp.picon.presentation.base.BaseFragment
+import com.yapp.picon.presentation.profile.FriendProfileActivity
 
 class ManageFriendTabFragment(
     private val isFollowing: Boolean
@@ -33,7 +35,8 @@ class ManageFriendTabFragment(
             R.layout.manage_friend_tab_list_item,
             BR.followItem,
             {id -> requestFollow(id)},
-            {id -> requestUnFollow(id)}
+            {id -> requestUnFollow(id)},
+            {identity -> startFriendProfile(identity)}
         )
         binding.manageFriendTabRv.apply {
             adapter = followAdapter
@@ -77,5 +80,12 @@ class ManageFriendTabFragment(
         if (vm.token.isNotEmpty()) {
             vm.requestUnFollow(vm.token, id)
         } else vm.showToast("언팔로우 실패")
+    }
+
+    private fun startFriendProfile(identity: String) {
+        startActivity(
+            Intent(context, FriendProfileActivity::class.java)
+                .putExtra("identity", identity)
+        )
     }
 }

--- a/Picon/app/src/main/java/com/yapp/picon/presentation/postdetail/PostDetailActivity.kt
+++ b/Picon/app/src/main/java/com/yapp/picon/presentation/postdetail/PostDetailActivity.kt
@@ -12,7 +12,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.WindowManager
 import androidx.core.app.ActivityOptionsCompat
-import androidx.core.util.Pair
 import androidx.databinding.DataBindingUtil
 import androidx.viewpager2.widget.ViewPager2
 import com.yapp.picon.BR
@@ -24,7 +23,6 @@ import com.yapp.picon.presentation.model.Emotion
 import com.yapp.picon.presentation.model.Post
 import com.yapp.picon.presentation.nav.repository.EmotionDatabaseRepository
 import org.koin.androidx.viewmodel.ext.android.viewModel
-import java.nio.file.Files.move
 
 class PostDetailActivity: BaseActivity<PostDetailActivityBinding, PostDetailViewModel>(
     R.layout.post_detail_activity
@@ -46,8 +44,8 @@ class PostDetailActivity: BaseActivity<PostDetailActivityBinding, PostDetailView
             imagePagerAdapter.setItems(it)
         })
         vm.content.observe(this, {
-            if (it.isEmpty()) binding.postDetailContentText.visibility = View.GONE
-            else binding.postDetailContentText.visibility = View.VISIBLE
+            if (it.isEmpty()) binding.postDetailScrollView.visibility = View.GONE
+            else binding.postDetailScrollView.visibility = View.VISIBLE
         })
         vm.editIconFlag.observe(this, {
             if (it) {

--- a/Picon/app/src/main/java/com/yapp/picon/presentation/postdetail/PostDetailActivity.kt
+++ b/Picon/app/src/main/java/com/yapp/picon/presentation/postdetail/PostDetailActivity.kt
@@ -88,6 +88,10 @@ class PostDetailActivity: BaseActivity<PostDetailActivityBinding, PostDetailView
         super.onCreate(savedInstanceState)
         emotionDatabaseRepository = EmotionDatabaseRepository(application)
 
+        val isFriend = intent.getBooleanExtra("isFriend", true)
+        if (isFriend) binding.postDetailEditIconButton.visibility = View.GONE
+        else binding.postDetailEditIconButton.visibility = View.VISIBLE
+
         window.run {
             sharedElementEnterTransition = TransitionInflater.from(context).inflateTransition(android.R.transition.move)
             sharedElementExitTransition = TransitionInflater.from(context).inflateTransition(android.R.transition.move)

--- a/Picon/app/src/main/java/com/yapp/picon/presentation/profile/FriendProfileActivity.kt
+++ b/Picon/app/src/main/java/com/yapp/picon/presentation/profile/FriendProfileActivity.kt
@@ -17,6 +17,8 @@ class FriendProfileActivity: BaseActivity<FriendProfileActivityBinding, FriendPr
     R.layout.friend_profile_activity
 ) {
     private lateinit var postAdapter: MyProfilePostAdapter
+    private var userId: Int? = null
+
     override val vm: FriendProfileViewModel by viewModel()
 
     override fun initViewModel() {
@@ -33,6 +35,16 @@ class FriendProfileActivity: BaseActivity<FriendProfileActivityBinding, FriendPr
             postAdapter.setItems(it)
             postAdapter.notifyDataSetChanged()
         })
+        vm.member.observe(this, {
+            if (userId == null) userId = it.id
+            vm.requestPostList(it.id)
+        })
+    }
+
+    override fun onResume() {
+        super.onResume()
+
+        userId?.let { vm.requestPostList(it) }
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/Picon/app/src/main/java/com/yapp/picon/presentation/profile/FriendProfileActivity.kt
+++ b/Picon/app/src/main/java/com/yapp/picon/presentation/profile/FriendProfileActivity.kt
@@ -1,0 +1,22 @@
+package com.yapp.picon.presentation.profile
+
+import android.os.Bundle
+import com.yapp.picon.BR
+import com.yapp.picon.R
+import com.yapp.picon.databinding.FriendProfileActivityBinding
+import com.yapp.picon.presentation.base.BaseActivity
+import org.koin.androidx.viewmodel.ext.android.viewModel
+
+class FriendProfileActivity: BaseActivity<FriendProfileActivityBinding, FriendProfileViewModel>(
+    R.layout.friend_profile_activity
+) {
+    override val vm: FriendProfileViewModel by viewModel()
+
+    override fun initViewModel() {
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding.setVariable(BR.fpVM, vm)
+    }
+}

--- a/Picon/app/src/main/java/com/yapp/picon/presentation/profile/FriendProfileActivity.kt
+++ b/Picon/app/src/main/java/com/yapp/picon/presentation/profile/FriendProfileActivity.kt
@@ -1,6 +1,7 @@
 package com.yapp.picon.presentation.profile
 
 import android.os.Bundle
+import com.bumptech.glide.Glide
 import com.yapp.picon.BR
 import com.yapp.picon.R
 import com.yapp.picon.databinding.FriendProfileActivityBinding
@@ -14,7 +15,10 @@ class FriendProfileActivity: BaseActivity<FriendProfileActivityBinding, FriendPr
 
     override fun initViewModel() {
         vm.backButton.observe(this, {
-            onBackPressed()
+            if (it) onBackPressed()
+        })
+        vm.image.observe(this, {
+            setProfileImage(it)
         })
     }
 
@@ -24,5 +28,21 @@ class FriendProfileActivity: BaseActivity<FriendProfileActivityBinding, FriendPr
 
         val identity = intent.getStringExtra("identity")
         vm.requestFriendProfile(identity)
+    }
+
+    private fun setProfileImage(value: String) {
+        if (value.isNotEmpty()) {
+            Glide.with(this)
+                .load(value)
+                .centerCrop()
+                .circleCrop()
+                .into(binding.friendProfileUserImage)
+        } else {
+            Glide.with(this)
+                .load(R.drawable.profile_pic)
+                .centerCrop()
+                .circleCrop()
+                .into(binding.friendProfileUserImage)
+        }
     }
 }

--- a/Picon/app/src/main/java/com/yapp/picon/presentation/profile/FriendProfileActivity.kt
+++ b/Picon/app/src/main/java/com/yapp/picon/presentation/profile/FriendProfileActivity.kt
@@ -13,6 +13,9 @@ class FriendProfileActivity: BaseActivity<FriendProfileActivityBinding, FriendPr
     override val vm: FriendProfileViewModel by viewModel()
 
     override fun initViewModel() {
+        vm.backButton.observe(this, {
+            onBackPressed()
+        })
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/Picon/app/src/main/java/com/yapp/picon/presentation/profile/FriendProfileActivity.kt
+++ b/Picon/app/src/main/java/com/yapp/picon/presentation/profile/FriendProfileActivity.kt
@@ -34,6 +34,9 @@ class FriendProfileActivity: BaseActivity<FriendProfileActivityBinding, FriendPr
         vm.postList.observe(this, {
             postAdapter.setItems(it)
             postAdapter.notifyDataSetChanged()
+
+            if (it.isEmpty()) binding.friendProfileEmptyPostText.visibility = View.VISIBLE
+            else binding.friendProfileEmptyPostText.visibility = View.GONE
         })
         vm.member.observe(this, {
             if (userId == null) userId = it.id
@@ -102,6 +105,7 @@ class FriendProfileActivity: BaseActivity<FriendProfileActivityBinding, FriendPr
     private fun startPostDetailActivity(view: View, post: Post) {
         Intent(this, PostDetailActivity::class.java).apply {
             putExtra("post", post)
+            putExtra("isFriend", true)
         }.let {
             startActivity(it)
         }

--- a/Picon/app/src/main/java/com/yapp/picon/presentation/profile/FriendProfileActivity.kt
+++ b/Picon/app/src/main/java/com/yapp/picon/presentation/profile/FriendProfileActivity.kt
@@ -20,6 +20,9 @@ class FriendProfileActivity: BaseActivity<FriendProfileActivityBinding, FriendPr
         vm.image.observe(this, {
             setProfileImage(it)
         })
+        vm.isFollowing.observe(this, {
+            setFollowButton(it)
+        })
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -43,6 +46,23 @@ class FriendProfileActivity: BaseActivity<FriendProfileActivityBinding, FriendPr
                 .centerCrop()
                 .circleCrop()
                 .into(binding.friendProfileUserImage)
+        }
+    }
+
+    private fun setFollowButton(value: Boolean) {
+        binding.friendProfileFollowButton.apply {
+            if (value) {
+                setBackgroundResource(R.drawable.bg_un_follow_button)
+                text = "언팔로우"
+            } else {
+                setBackgroundResource(R.drawable.bg_follow_button)
+                text = "팔로우"
+            }
+
+            setOnClickListener {
+                if (value) vm.requestUnFollow()
+                else vm.requestFollow()
+            }
         }
     }
 }

--- a/Picon/app/src/main/java/com/yapp/picon/presentation/profile/FriendProfileActivity.kt
+++ b/Picon/app/src/main/java/com/yapp/picon/presentation/profile/FriendProfileActivity.kt
@@ -1,16 +1,22 @@
 package com.yapp.picon.presentation.profile
 
+import android.content.Intent
 import android.os.Bundle
+import android.view.View
+import androidx.recyclerview.widget.GridLayoutManager
 import com.bumptech.glide.Glide
 import com.yapp.picon.BR
 import com.yapp.picon.R
 import com.yapp.picon.databinding.FriendProfileActivityBinding
 import com.yapp.picon.presentation.base.BaseActivity
+import com.yapp.picon.presentation.model.Post
+import com.yapp.picon.presentation.postdetail.PostDetailActivity
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class FriendProfileActivity: BaseActivity<FriendProfileActivityBinding, FriendProfileViewModel>(
     R.layout.friend_profile_activity
 ) {
+    private lateinit var postAdapter: MyProfilePostAdapter
     override val vm: FriendProfileViewModel by viewModel()
 
     override fun initViewModel() {
@@ -23,11 +29,26 @@ class FriendProfileActivity: BaseActivity<FriendProfileActivityBinding, FriendPr
         vm.isFollowing.observe(this, {
             setFollowButton(it)
         })
+        vm.postList.observe(this, {
+            postAdapter.setItems(it)
+            postAdapter.notifyDataSetChanged()
+        })
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding.setVariable(BR.fpVM, vm)
+
+        postAdapter = MyProfilePostAdapter(this,
+            { view, post -> startPostDetailActivity(view, post) },
+            R.layout.my_profile_post_item,
+            BR.profilePost
+        )
+        binding.friendProfilePostRv.apply {
+            adapter = postAdapter
+            layoutManager = GridLayoutManager(context, 3)
+            setHasFixedSize(true)
+        }
 
         val identity = intent.getStringExtra("identity")
         vm.requestFriendProfile(identity)
@@ -63,6 +84,14 @@ class FriendProfileActivity: BaseActivity<FriendProfileActivityBinding, FriendPr
                 if (value) vm.requestUnFollow()
                 else vm.requestFollow()
             }
+        }
+    }
+
+    private fun startPostDetailActivity(view: View, post: Post) {
+        Intent(this, PostDetailActivity::class.java).apply {
+            putExtra("post", post)
+        }.let {
+            startActivity(it)
         }
     }
 }

--- a/Picon/app/src/main/java/com/yapp/picon/presentation/profile/FriendProfileActivity.kt
+++ b/Picon/app/src/main/java/com/yapp/picon/presentation/profile/FriendProfileActivity.kt
@@ -18,5 +18,8 @@ class FriendProfileActivity: BaseActivity<FriendProfileActivityBinding, FriendPr
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding.setVariable(BR.fpVM, vm)
+
+        val identity = intent.getStringExtra("identity")
+        vm.requestFriendProfile(identity)
     }
 }

--- a/Picon/app/src/main/java/com/yapp/picon/presentation/profile/FriendProfileViewModel.kt
+++ b/Picon/app/src/main/java/com/yapp/picon/presentation/profile/FriendProfileViewModel.kt
@@ -1,6 +1,7 @@
 package com.yapp.picon.presentation.profile
 
 import android.util.Log
+import android.view.View
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
@@ -13,6 +14,9 @@ import kotlinx.coroutines.launch
 class FriendProfileViewModel(
     private val loadAccessTokenUseCase: LoadAccessTokenUseCase
 ): BaseViewModel() {
+    private val _backButton = MutableLiveData<Boolean>()
+    val backButton: LiveData<Boolean> get() =  _backButton
+
     private val _member = MutableLiveData<Members>()
     val member: LiveData<Members> get() =  _member
 
@@ -55,6 +59,12 @@ class FriendProfileViewModel(
             } catch (e: Exception) {
                 Log.e("FriendProfileViewModel","requestFriendProfile error - ${e.message}")
             }
+        }
+    }
+
+    fun clickBackButton(view: View) {
+        _backButton.value?.let {
+            _backButton.value = !it
         }
     }
 }

--- a/Picon/app/src/main/java/com/yapp/picon/presentation/profile/FriendProfileViewModel.kt
+++ b/Picon/app/src/main/java/com/yapp/picon/presentation/profile/FriendProfileViewModel.kt
@@ -9,6 +9,7 @@ import com.yapp.picon.data.model.Members
 import com.yapp.picon.data.network.NetworkModule
 import com.yapp.picon.domain.usecase.LoadAccessTokenUseCase
 import com.yapp.picon.presentation.base.BaseViewModel
+import com.yapp.picon.presentation.model.Post
 import kotlinx.coroutines.launch
 
 class FriendProfileViewModel(
@@ -35,12 +36,19 @@ class FriendProfileViewModel(
     private val _follower = MutableLiveData<Int>()
     val follower: LiveData<Int> get() =  _follower
 
+    private val _postList = MutableLiveData<List<Post>>()
+    val postList: LiveData<List<Post>> get() = _postList
+
     init {
         // todo - following, follower 수 받아오기
         _following.value = 0
         _follower.value = 0
 
         _backButton.value = false
+    }
+
+    fun requestPostList() {
+        // todo - 친구 게시물 리스트 받아오기
     }
 
     fun requestFriendProfile(input: String) {

--- a/Picon/app/src/main/java/com/yapp/picon/presentation/profile/FriendProfileViewModel.kt
+++ b/Picon/app/src/main/java/com/yapp/picon/presentation/profile/FriendProfileViewModel.kt
@@ -1,6 +1,60 @@
 package com.yapp.picon.presentation.profile
 
+import android.util.Log
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.viewModelScope
+import com.yapp.picon.data.model.Members
+import com.yapp.picon.data.network.NetworkModule
+import com.yapp.picon.domain.usecase.LoadAccessTokenUseCase
 import com.yapp.picon.presentation.base.BaseViewModel
+import kotlinx.coroutines.launch
 
-class FriendProfileViewModel: BaseViewModel() {
+class FriendProfileViewModel(
+    private val loadAccessTokenUseCase: LoadAccessTokenUseCase
+): BaseViewModel() {
+    private val _member = MutableLiveData<Members>()
+    val member: LiveData<Members> get() =  _member
+
+    private val _nickname = MutableLiveData<String>()
+    val nickname: LiveData<String> get() =  _nickname
+
+    private val _image = MutableLiveData<String>()
+    val image: LiveData<String> get() =  _image
+
+    private val _isFollowing = MutableLiveData<Boolean>()
+    val isFollowing: LiveData<Boolean> get() =  _isFollowing
+
+    private val _following = MutableLiveData<Int>()
+    val following: LiveData<Int> get() =  _following
+
+    private val _follower = MutableLiveData<Int>()
+    val follower: LiveData<Int> get() =  _follower
+
+    init {
+        // todo - following, follower 수 받아오기
+        _following.value = 0
+        _follower.value = 0
+    }
+
+    fun requestFriendProfile(input: String) {
+        viewModelScope.launch {
+            try {
+                loadAccessTokenUseCase().let { token ->
+                    if (token.isNotEmpty()) {
+                        NetworkModule.yappApi.requestAllUser(token, input).let {
+                            it.members[0].run {
+                                _member.value = this
+                                _nickname.value = this.nickName
+                                _image.value = this.profileImageUrl ?: ""
+                                _isFollowing.value = this.isFollowing ?: false
+                            }
+                        }
+                    } else Log.e("FriendProfileViewModel","requestFriendProfile - token is empty")
+                }
+            } catch (e: Exception) {
+                Log.e("FriendProfileViewModel","requestFriendProfile error - ${e.message}")
+            }
+        }
+    }
 }

--- a/Picon/app/src/main/java/com/yapp/picon/presentation/profile/FriendProfileViewModel.kt
+++ b/Picon/app/src/main/java/com/yapp/picon/presentation/profile/FriendProfileViewModel.kt
@@ -64,6 +64,40 @@ class FriendProfileViewModel(
         }
     }
 
+    fun requestFollow() {
+        viewModelScope.launch {
+            try {
+                loadAccessTokenUseCase().let { token ->
+                    if (token.isNotEmpty()) {
+                        _member.value?.let {
+                            NetworkModule.yappApi.requestFollow(token, it.id)
+                            _isFollowing.value = true
+                        }
+                    } else Log.e("FriendProfileViewModel","requestFollow - token is empty")
+                }
+            } catch (e: Exception) {
+                Log.e("FriendProfileViewModel","requestFollow error - ${e.message}")
+            }
+        }
+    }
+
+    fun requestUnFollow() {
+        viewModelScope.launch {
+            try {
+                loadAccessTokenUseCase().let { token ->
+                    if (token.isNotEmpty()) {
+                        _member.value?.let {
+                            NetworkModule.yappApi.requestUnFollow(token, it.id)
+                            _isFollowing.value = false
+                        }
+                    } else Log.e("FriendProfileViewModel","requestUnFollow - token is empty")
+                }
+            } catch (e: Exception) {
+                Log.e("FriendProfileViewModel","requestUnFollow error - ${e.message}")
+            }
+        }
+    }
+
     fun clickBackButton(view: View) {
         _backButton.value?.let {
             _backButton.value = !it

--- a/Picon/app/src/main/java/com/yapp/picon/presentation/profile/FriendProfileViewModel.kt
+++ b/Picon/app/src/main/java/com/yapp/picon/presentation/profile/FriendProfileViewModel.kt
@@ -39,6 +39,8 @@ class FriendProfileViewModel(
         // todo - following, follower 수 받아오기
         _following.value = 0
         _follower.value = 0
+
+        _backButton.value = false
     }
 
     fun requestFriendProfile(input: String) {

--- a/Picon/app/src/main/java/com/yapp/picon/presentation/profile/FriendProfileViewModel.kt
+++ b/Picon/app/src/main/java/com/yapp/picon/presentation/profile/FriendProfileViewModel.kt
@@ -1,0 +1,6 @@
+package com.yapp.picon.presentation.profile
+
+import com.yapp.picon.presentation.base.BaseViewModel
+
+class FriendProfileViewModel: BaseViewModel() {
+}

--- a/Picon/app/src/main/java/com/yapp/picon/presentation/profile/MyProfileActivity.kt
+++ b/Picon/app/src/main/java/com/yapp/picon/presentation/profile/MyProfileActivity.kt
@@ -101,6 +101,7 @@ class MyProfileActivity: BaseActivity<MyProfileActivityBinding, MyProfileViewMod
     private fun startPostDetailActivity(view: View, post: Post) {
         Intent(this, PostDetailActivity::class.java).apply {
             putExtra("post", post)
+            putExtra("isFriend", false)
         }.let {
             startActivity(it)
         }

--- a/Picon/app/src/main/java/com/yapp/picon/presentation/profile/MyProfileActivity.kt
+++ b/Picon/app/src/main/java/com/yapp/picon/presentation/profile/MyProfileActivity.kt
@@ -47,6 +47,9 @@ class MyProfileActivity: BaseActivity<MyProfileActivityBinding, MyProfileViewMod
         vm.postList.observe(this, {
             postAdapter.setItems(it)
             postAdapter.notifyDataSetChanged()
+
+            if (it.isEmpty()) binding.myProfileEmptyPostText.visibility = View.VISIBLE
+            else binding.myProfileEmptyPostText.visibility = View.GONE
         })
     }
 

--- a/Picon/app/src/main/java/com/yapp/picon/presentation/profile/MyProfileViewModel.kt
+++ b/Picon/app/src/main/java/com/yapp/picon/presentation/profile/MyProfileViewModel.kt
@@ -50,6 +50,8 @@ class MyProfileViewModel: BaseViewModel() {
                 NetworkModule.yappApi.requestUserInfo(token).let {
                     _myProfileTitle.value = it.member.nickName
                     _profileImageUrl.value = it.member.profileImageUrl ?: ""
+                    _following.value = it.followInfo.followings
+                    _follower.value = it.followInfo.followers
                 }
             } catch (e: Exception) {
                 Log.e("MyProfileViewModel", "requestUserInfo Error - ${e.message}")

--- a/Picon/app/src/main/res/layout/dialog_custom_emotion.xml
+++ b/Picon/app/src/main/res/layout/dialog_custom_emotion.xml
@@ -36,6 +36,7 @@
             android:layout_height="32dp"
             android:layout_marginStart="18dp"
             android:layout_marginEnd="28dp"
+            android:maxLength="9"
             android:background="@drawable/bg_edit_text"
             android:ems="10"
             android:inputType="text"

--- a/Picon/app/src/main/res/layout/friend_profile_activity.xml
+++ b/Picon/app/src/main/res/layout/friend_profile_activity.xml
@@ -44,6 +44,7 @@
                     android:layout_height="wrap_content"
                     android:textColor="@color/very_light_pink"
                     android:textSize="16sp"
+                    android:text="@{fpVM.nickname}"
                     app:layout_constraintBottom_toBottomOf="@+id/friend_profile_back_iv"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
@@ -103,6 +104,7 @@
                 android:id="@+id/friend_profile_following_number"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:text="@{fpVM.following.toString()}"
                 android:textColor="@color/pale_grey"
                 android:textSize="16sp" />
 
@@ -127,6 +129,7 @@
                 android:id="@+id/friend_profile_follower_number"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:text="@{fpVM.follower.toString()}"
                 android:textColor="@color/pale_grey"
                 android:textSize="16sp" />
 

--- a/Picon/app/src/main/res/layout/friend_profile_activity.xml
+++ b/Picon/app/src/main/res/layout/friend_profile_activity.xml
@@ -136,6 +136,17 @@
 
         </LinearLayout>
 
+        <TextView
+            android:id="@+id/friend_profile_empty_post_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/friend_profile_empty_post_list"
+            android:textColor="@color/greyish_brown"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/friend_profile_follow_linear_layout" />
+
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/friend_profile_post_rv"
             android:layout_width="match_parent"

--- a/Picon/app/src/main/res/layout/friend_profile_activity.xml
+++ b/Picon/app/src/main/res/layout/friend_profile_activity.xml
@@ -9,7 +9,7 @@
         android:background="@color/dark_grey">
 
         <androidx.appcompat.widget.Toolbar
-            android:id="@+id/other_profile_tool_bar"
+            android:id="@+id/friend_profile_tool_bar"
             android:layout_width="match_parent"
             android:layout_height="74dp"
             android:background="#00ffffff"
@@ -23,7 +23,7 @@
                 android:layout_height="match_parent">
 
                 <ImageView
-                    android:id="@+id/other_profile_back_iv"
+                    android:id="@+id/friend_profile_back_iv"
                     android:layout_width="60dp"
                     android:layout_height="60dp"
                     android:contentDescription="@string/image_description"
@@ -33,15 +33,15 @@
                     app:layout_constraintStart_toStartOf="parent" />
 
                 <TextView
-                    android:id="@+id/other_profile_title_tv"
+                    android:id="@+id/friend_profile_title_tv"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:textColor="@color/very_light_pink"
                     android:textSize="16sp"
-                    app:layout_constraintBottom_toBottomOf="@+id/other_profile_back_iv"
+                    app:layout_constraintBottom_toBottomOf="@+id/friend_profile_back_iv"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="@+id/other_profile_back_iv" />
+                    app:layout_constraintTop_toTopOf="@+id/friend_profile_back_iv" />
 
 
             </androidx.constraintlayout.widget.ConstraintLayout>
@@ -49,17 +49,17 @@
         </androidx.appcompat.widget.Toolbar>
 
         <ImageView
-            android:id="@+id/other_profile_user_image"
+            android:id="@+id/friend_profile_user_image"
             android:layout_width="74dp"
             android:layout_height="74dp"
             android:layout_marginTop="2dp"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/other_profile_tool_bar"
+            app:layout_constraintTop_toBottomOf="@+id/friend_profile_tool_bar"
             app:srcCompat="@drawable/profile_pic" />
 
         <Button
-            android:id="@+id/other_profile_follow_button"
+            android:id="@+id/friend_profile_follow_button"
             android:layout_width="wrap_content"
             android:layout_height="32dp"
             android:layout_marginTop="12dp"
@@ -71,10 +71,10 @@
             android:textSize="13sp"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/other_profile_user_image" />
+            app:layout_constraintTop_toBottomOf="@+id/friend_profile_user_image" />
 
         <LinearLayout
-            android:id="@+id/other_profile_follow_linear_layout"
+            android:id="@+id/friend_profile_follow_linear_layout"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="18dp"
@@ -82,10 +82,10 @@
             android:orientation="horizontal"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/other_profile_follow_button">
+            app:layout_constraintTop_toBottomOf="@+id/friend_profile_follow_button">
 
             <TextView
-                android:id="@+id/other_profile_following_text"
+                android:id="@+id/friend_profile_following_text"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="12dp"
@@ -94,7 +94,7 @@
                 android:textSize="14sp" />
 
             <TextView
-                android:id="@+id/other_profile_following_number"
+                android:id="@+id/friend_profile_following_number"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:textColor="@color/pale_grey"
@@ -109,7 +109,7 @@
                 android:background="@color/brownish_grey" />
 
             <TextView
-                android:id="@+id/other_profile_follower_text"
+                android:id="@+id/friend_profile_follower_text"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="12dp"
@@ -118,7 +118,7 @@
                 android:textSize="14sp" />
 
             <TextView
-                android:id="@+id/other_profile_follower_number"
+                android:id="@+id/friend_profile_follower_number"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:textColor="@color/pale_grey"
@@ -127,14 +127,14 @@
         </LinearLayout>
 
         <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/other_profile_post_rv"
+            android:id="@+id/friend_profile_post_rv"
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_marginTop="31dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/other_profile_follow_linear_layout" />
+            app:layout_constraintTop_toBottomOf="@+id/friend_profile_follow_linear_layout" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/Picon/app/src/main/res/layout/friend_profile_activity.xml
+++ b/Picon/app/src/main/res/layout/friend_profile_activity.xml
@@ -32,6 +32,7 @@
                     android:id="@+id/friend_profile_back_iv"
                     android:layout_width="60dp"
                     android:layout_height="60dp"
+                    android:onClick="@{fpVM::clickBackButton}"
                     android:contentDescription="@string/image_description"
                     android:padding="18dp"
                     android:src="@drawable/ic_back"

--- a/Picon/app/src/main/res/layout/friend_profile_activity.xml
+++ b/Picon/app/src/main/res/layout/friend_profile_activity.xml
@@ -3,6 +3,12 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
+    <data>
+        <variable
+            name="fpVM"
+            type="com.yapp.picon.presentation.profile.FriendProfileViewModel" />
+    </data>
+
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/Picon/app/src/main/res/layout/manage_friend_tab_list_item.xml
+++ b/Picon/app/src/main/res/layout/manage_friend_tab_list_item.xml
@@ -31,7 +31,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="10dp"
-            android:text="@{followItem.email}"
+            android:text="@{followItem.nickname}"
             android:textColor="@color/pale_grey"
             android:textSize="13sp"
             app:layout_constraintBottom_toBottomOf="parent"

--- a/Picon/app/src/main/res/layout/map_nav_head.xml
+++ b/Picon/app/src/main/res/layout/map_nav_head.xml
@@ -54,6 +54,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="8dp"
                 android:layout_marginEnd="28dp"
+                android:layout_marginBottom="12dp"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"

--- a/Picon/app/src/main/res/layout/my_profile_activity.xml
+++ b/Picon/app/src/main/res/layout/my_profile_activity.xml
@@ -132,6 +132,17 @@
                 android:textSize="16sp" />
         </LinearLayout>
 
+        <TextView
+            android:id="@+id/my_profile_empty_post_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/friend_profile_empty_post_list"
+            android:textColor="@color/greyish_brown"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/my_profile_follow_linear_layout" />
+
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/my_profile_post_rv"
             android:layout_width="match_parent"

--- a/Picon/app/src/main/res/layout/post_detail_activity.xml
+++ b/Picon/app/src/main/res/layout/post_detail_activity.xml
@@ -77,6 +77,7 @@
                 android:layout_marginTop="6dp"
                 android:layout_marginEnd="19dp"
                 app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHeight_max="96dp"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/post_detail_address_text">
 
@@ -92,7 +93,7 @@
                         android:text="@{postDetailVM.content}"
                         android:textColor="@color/pale_grey"
                         android:textSize="14sp"
-                        android:visibility="visible"/>
+                        android:visibility="visible" />
 
                 </LinearLayout>
 

--- a/Picon/app/src/main/res/layout/post_detail_activity.xml
+++ b/Picon/app/src/main/res/layout/post_detail_activity.xml
@@ -69,21 +69,34 @@
                 app:layout_constraintStart_toEndOf="@+id/post_detail_color_circle_image"
                 app:layout_constraintTop_toTopOf="@+id/post_detail_color_circle_image" />
 
-            <TextView
-                android:id="@+id/post_detail_content_text"
+            <ScrollView
+                android:id="@+id/post_detail_scroll_view"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="19dp"
                 android:layout_marginTop="6dp"
                 android:layout_marginEnd="19dp"
-                android:text="@{postDetailVM.content}"
-                android:textColor="@color/pale_grey"
-                android:textSize="14sp"
-                android:visibility="visible"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/post_detail_address_text"
-                app:lineHeight="24sp" />
+                app:layout_constraintTop_toBottomOf="@+id/post_detail_address_text">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical">
+
+                    <TextView
+                        android:id="@+id/post_detail_content_text"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@{postDetailVM.content}"
+                        android:textColor="@color/pale_grey"
+                        android:textSize="14sp"
+                        android:visibility="visible"/>
+
+                </LinearLayout>
+
+            </ScrollView>
 
             <TextView
                 android:id="@+id/post_detail_date_text"
@@ -95,7 +108,7 @@
                 android:textColor="@color/brown_grey"
                 android:textSize="12sp"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/post_detail_content_text" />
+                app:layout_constraintTop_toBottomOf="@+id/post_detail_scroll_view" />
 
             <ImageView
                 android:id="@+id/post_detail_edit_icon_button"

--- a/Picon/app/src/main/res/values/strings.xml
+++ b/Picon/app/src/main/res/values/strings.xml
@@ -38,6 +38,7 @@
     <string name="nav_statistic_place">서울 강남구</string>
 
     <string name="manage_friend_edit_hint">닉네임 또는 이메일을 검색하세요</string>
+    <string name="friend_profile_empty_post_list">게시물이 존재하지 않습니다.</string>
 
     <string name="dialog_custom_remove_post_title">핀을 삭제하시겠습니까?</string>
     <string name="dialog_custom_emotion_title">색상에 어울리는 감정을 정해주세요.</string>


### PR DESCRIPTION
#76 
* 뒤로가기 버튼 활성화
* 프로필 이미지 / 닉네임 텍스트에 api 데이터 적용
* 팔로우 버튼 기능 활성화
* 친구 게시물 recycler view 어댑터 생성 및 적용
* 게시물 아이템 클릭 시, 게시물 보기 화면 연결
* 친구 게시물 보기 화면에서는 편집 버튼 제거
* 친구 게시물 recycler view에 item 데이터 적용

-> 아직 팔로잉, 팔로워 수 api 데이터 적용은 하지 못했습니다. 서버에서 회원검색 api에 팔로잉/팔로워 수 가 추가되는대로 적용하겠습니다. 그 외 기능들은 모두 구현 끝났습니다.